### PR TITLE
add fields for time and for repeated stats

### DIFF
--- a/protoStat/protoStat.proto
+++ b/protoStat/protoStat.proto
@@ -17,8 +17,10 @@ message protoStat {
 	required string key = 1;
 	optional double value = 2;
 	optional string indexKey = 3;
+	optional bool repeat = 4;
 }
 
 message protoStats {
 	repeated protoStat stats = 1;
+    optional int64 timeNano = 2;
 }


### PR DESCRIPTION
- time is in nano seconds
- repeated is so that we can initialize a stat to continue to report even if we don't get any stats for it.  (example failed count.. if nothing is failing it should report a 0 every interval)
